### PR TITLE
Set `midi.RawInstreamFile.infile` as a string, not as a file descriptor anymore 

### DIFF
--- a/fretwork/midi/RawInstreamFile.py
+++ b/fretwork/midi/RawInstreamFile.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from DataTypeConverters import readBew, readVar, varLen
+from DataTypeConverters import readBew
+from DataTypeConverters import readVar
+from DataTypeConverters import varLen
 
 
 class RawInstreamFile(object):
@@ -49,7 +51,6 @@ class RawInstreamFile(object):
         "Moves the cursor to a new relative position"
         self.cursor += relative_position
 
-    # native data reading functions
     def nextSlice(self, length, move_cursor=1):
         "Reads the next text slice from the raw data, with length"
         c = self.cursor
@@ -70,21 +71,8 @@ class RawInstreamFile(object):
         Reads a variable length value from the current cursor position.
         Moves cursor if move_cursor is true
         """
-        MAX_VARLEN = 4 # Max value varlen can be
+        MAX_VARLEN = 4  # Max value varlen can be
         var = readVar(self.nextSlice(MAX_VARLEN, 0))
         # only move cursor the actual bytes in varlen
         self.moveCursor(varLen(var))
         return var
-
-
-if __name__ == '__main__':
-
-    test_file = 'test/midifiles/minimal.mid'
-    fis = RawInstreamFile(test_file)
-    print(fis.nextSlice(len(fis.data)))
-
-    test_file = 'test/midifiles/cubase-minimal.mid'
-    cubase_minimal = open(test_file, 'rb')
-    fis2 = RawInstreamFile(cubase_minimal)
-    print(fis2.nextSlice(len(fis2.data)))
-    cubase_minimal.close()

--- a/fretwork/midi/RawInstreamFile.py
+++ b/fretwork/midi/RawInstreamFile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from DataTypeConverters import readBew
+from DataTypeConverters import readBew as readBew_
 from DataTypeConverters import readVar
 from DataTypeConverters import varLen
 
@@ -64,7 +64,7 @@ class RawInstreamFile(object):
         Reads n bytes of date from the current cursor position.
         Moves cursor if move_cursor is true
         """
-        return readBew(self.nextSlice(n_bytes, move_cursor))
+        return readBew_(self.nextSlice(n_bytes, move_cursor))
 
     def readVarLen(self):
         """

--- a/fretwork/midi/RawInstreamFile.py
+++ b/fretwork/midi/RawInstreamFile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import os.path
+
 from DataTypeConverters import readBew as readBew_
 from DataTypeConverters import readVar
 from DataTypeConverters import varLen
@@ -15,23 +17,17 @@ class RawInstreamFile(object):
 
     def __init__(self, infile=''):
         """
-        If 'file' is a string we assume it is a path and read from
-        that file.
-        If it is a file descriptor we read from the file, but we don't
-        close it.
         Midi files are usually pretty small, so it should be safe to
         copy them into memory.
+
+        :param infile: name of the file where data come from.
         """
-        if infile:
-            if type(infile) in [str, unicode]:
-                infile = open(infile, 'rb')
-                self.data = infile.read()
-                infile.close()
-            else:
-                # don't close the f
-                self.data = infile.read()
+        if infile and os.path.isfile(infile):
+            with open(infile, 'rb') as f:
+                self.data = f.read()
         else:
             self.data = ''
+
         # start at beginning ;-)
         self.cursor = 0
 


### PR DESCRIPTION
This will simplify the class and remove unicode incompatibilities in python 3.