### PR TITLE
Doc: update class & module contents

### DIFF
--- a/doc/source/code/fretwork.midi.rst
+++ b/doc/source/code/fretwork.midi.rst
@@ -91,12 +91,3 @@ fretwork\.midi\.constants module
     :members:
     :undoc-members:
     :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: fretwork.midi
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/doc/source/code/fretwork.mixstream.rst
+++ b/doc/source/code/fretwork.mixstream.rst
@@ -8,3 +8,8 @@ Module contents
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autoclass:: fretwork.mixstream.VorbisFileMixStream
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
- Remove the useless Midi module content (there are already its classes contents)
- add the ``mixstream.VorbisFileMixStream`` class content.