### PR TITLE
Use the long_description_content_type metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,7 @@ setup(
     version=version_number,
     description='Game library used by FoFiX, and FoF:R.',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Matthew Sitton and contributors',
     author_email='matthewsitton@gmail.com',
     license='GPLv2+',


### PR DESCRIPTION
This option let us use the markdown syntax in the long description.