### PR TITLE
Logs: make the log level customizable

### DIFF
--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -5,6 +5,7 @@ Release notes
 ------------------
 
 - Pin versions
+- Make the log level customizable
 
 
 0.3.0 (2017-11-09)

--- a/fretwork/log.py
+++ b/fretwork/log.py
@@ -4,7 +4,7 @@
 #####################################################################
 # Fretwork                                                          #
 # Copyright (C) 2006 Sami Kyöstilä                                  #
-#               2009-2017 FoFiX Team                                #
+#               2009-2018 FoFiX Team                                #
 #                                                                   #
 # This program is free software; you can redistribute it and/or     #
 # modify it under the terms of the GNU General Public License       #
@@ -33,7 +33,7 @@ Configure the logger in your launcher::
     from fretwork import log
 
     # configure the logger
-    log.configure('file.log')
+    log.configure('file.log', logging.DEBUG)
 
 
 Import and use it::
@@ -47,11 +47,16 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 
-def configure(log_filename):
-    """Configure logging"""
+def configure(log_filename, log_level=logging.INFO):
+    """
+    Configure logging.
+
+    :param log_filename: name of the file where logs are saved.
+    :param log_level: level of logs (default: logging.INFO).
+    """
     # create the logger
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger.setLevel(log_level)
 
     # formatter
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -59,7 +64,7 @@ def configure(log_filename):
     handler_filename = log_filename
     handler_max = 1000000  # 1 Mo
     file_handler = RotatingFileHandler(handler_filename, 'a', handler_max, 1)
-    file_handler.setLevel(logging.INFO)
+    file_handler.setLevel(log_level)
 
     # set handlers
     file_handler.setFormatter(formatter)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # FoFiX
-# Copyright (C) 2017 FoFiX team
+# Copyright (C) 2017-2018 FoFiX team
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@ class ConfigureTest(unittest.TestCase):
 
     def test_logger(self):
         # configurer the logger
+        #log.configure(self.logfile.name, logging.INFO)
         log.configure(self.logfile.name)
         self.assertTrue(os.path.exists(self.logfile.name))
 
@@ -45,3 +46,26 @@ class ConfigureTest(unittest.TestCase):
         log_msg = self.logfile.readline().decode()
         self.assertIn('INFO', log_msg)
         self.assertIn(msg, log_msg)
+
+    def test_logger_warning_level(self):
+        # configurer the logger in Warning level
+        #log.configure(self.logfile.name, logging.WARNING)
+        log.configure(self.logfile.name, 'WARNING')
+
+        # log two messages
+        logger = logging.getLogger(__name__)
+        msg_info = "Test info log"
+        msg_warning = "Test warning log"
+        logger.info(msg_info)
+        logger.warning(msg_warning)
+
+        # read the log file
+        log_msgs = self.logfile.readlines()
+        self.assertEqual(len(log_msgs), 1)
+        log_msg = log_msgs[0].decode()
+
+        # check the log file content
+        self.assertNotIn('INFO', log_msg)
+        self.assertNotIn(msg_info, log_msg)
+        self.assertIn('WARNING', log_msg)
+        self.assertIn(msg_warning, log_msg)


### PR DESCRIPTION
This will be useful to switch between multiple levels, for example for debugging.
Update tests and release notes too.

Fix #40