### PR TITLE
Doc: update release notes for the unreleased 0.4.0 version

### DIFF
--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -16,6 +16,8 @@ Release notes
 - Tests: add some tests for the `Task` module
 - Deps: remove `Pillow` from requirements
 
+Details: https://github.com/fofix/fretwork/milestone/2?closed=1
+
 
 0.3.0 (2017-11-09)
 ------------------
@@ -25,6 +27,8 @@ Release notes
 - add docs
 - add tests
 - release on PyPi
+
+Details: https://github.com/fofix/fretwork/milestone/1?closed=1
 
 
 0.2.0 (2015-11-22)

--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -6,6 +6,15 @@ Release notes
 
 - Pin versions
 - Make the log level customizable
+- Syntax: fix relative imports in the `midi` module
+- Python 3: fix an exception syntax in `midi.EventDispatcher`
+- Python 3: Use python3 imports for `StringIO` and `StringType`
+- Doc: remove the useless `midi` module content
+- Doc: add the `mixstream.VorbisFileMixStream` content
+- Tests: add some tests for `midi.MidiInFile`
+- Tests: add some tests for `midi.DataTypeConverters`
+- Tests: add some tests for the `Task` module
+- Deps: remove `Pillow` from requirements
 
 
 0.3.0 (2017-11-09)


### PR DESCRIPTION
Add missing release notes and link each version notes to its milestone if it exists.