### PR TITLE
Travis: add some python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: python
 python:
     - 2.7
+    - 3.4
+    - 3.5
     - 3.6
+    - "3.7-dev"
+
+matrix:
+    allow_failures:
+        - python: "3.7-dev"
 
 before_install:
     - sudo apt-get -qq update

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ serialize = {major}.{minor}
 
 [bumpversion:file:doc/source/conf.py]
 
-[bumpversion:file:doc/source/releasenotes.rst]
-search = (unreleased)
-replace = ({now:%Y-%m-%d})
+#[bumpversion:file:doc/source/releasenotes.rst]
+#search = (unreleased)
+#replace = ({now:%Y-%m-%d})
 
 [flake8]
 # E121 continuation line under-indented for hanging indent


### PR DESCRIPTION
Add versions 3.4, 3.5 and 3.7-dev to the Travis CI.
Comment the bumpversion config containing "%" due to an exception raised by configparser.