### PR TITLE
Doc: remove a wrong option

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -87,4 +87,4 @@ All
 - Make a wheel::
 
     python.exe setup.py sdist
-    python.exe setup.py bdist_wheel --inplace
+    python.exe setup.py bdist_wheel


### PR DESCRIPTION
The option `inplace` is not for `bdist_wheel` but for `build_ext`.