### PR TITLE
MixStream / Windows: replace dprintf with fdprintf

### DIFF
--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -4,6 +4,8 @@ Release notes
 1.0.0 (unreleased)
 ------------------
 
+- Windows: replace `dprintf` with `fdprintf` (MixStream)
+
 Details: https://github.com/fofix/fretwork/milestone/3?closed=1
 
 

--- a/fretwork/mixstream/MixStream.c
+++ b/fretwork/mixstream/MixStream.c
@@ -58,6 +58,23 @@ static GStaticMutex chan_table_mutex = G_STATIC_MUTEX_INIT;
 static void _mix_stream_soundtouchify(MixStream* stream);
 
 
+/*
+ * dprintf: https://linux.die.net/man/3/dprintf
+ * see https://stackoverflow.com/a/2113927/5222966
+ */
+int fdprintf(int fd, const char *fmt, ...) {
+  va_list ap;
+  FILE *f = fdopen(fd, "r");
+  int rc;
+
+  va_start(ap, fmt);
+  rc = vfprintf(f, fmt, ap);
+  fclose(f);
+  va_end(ap);
+  return rc;
+}
+
+
 /* Create a stream that will play data returned by read_cb.
  *   - samprate and channels specify the format returned by read_cb
  *   - seek_cb is called to attempt a seek (may be NULL if not implemented)
@@ -88,7 +105,7 @@ MixStream* mix_stream_new(int samprate, int channels, mix_stream_read_cb read_cb
 
   // Init SDL_mixer
   if (Mix_OpenAudio(44100, AUDIO_S16SYS, 2, 1024) < 0) {
-      dprintf(2, "Error initializing SDL_mixer: %s\n", Mix_GetError());
+      fdprintf(2, "Error initializing SDL_mixer: %s\n", Mix_GetError());
       g_free(stream);
       return NULL;
   }

--- a/fretwork/mixstream/MixStream.h
+++ b/fretwork/mixstream/MixStream.h
@@ -25,6 +25,8 @@
 
 typedef struct _MixStream MixStream;
 
+int fdprintf(int fd, const char *fmt, ...);
+
 typedef gsize(*mix_stream_read_cb)(float* buf, gsize bufsize, void* data);
 typedef double(*mix_stream_seek_cb)(double time, void* data);
 typedef double(*mix_stream_length_cb)(void* data);


### PR DESCRIPTION
To be able to compile the MixStream extension under Windows, `dprintf`
is replaced by `fdprintf` which uses `fdopen`.

Update release notes.