### PR TITLE
Setup: replace os.spawnl with subprocess.call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,12 +71,13 @@ def pc_exists(pkg):
     return subprocess.call([pkg_config, '--print-errors', '--exists', pkg]) == 0
 
 
-def pc_info(pkg, altnames=[]):
+def pc_info(pkg, altnames=None):
     '''Obtain build options for a library from pkg-config and
     return a dict that can be expanded into the argument list for
     L{distutils.core.Extension}.'''
 
     sys.stdout.write('checking for library %s... ' % pkg)
+    altnames = altnames if altnames is not None else list()
     if not pc_exists(pkg):
         for name in altnames:
             if pc_exists(name):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 #####################################################################
 #                                                                   #
 # Fretwork                                                          #
-# Copyright (C) 2009-2015 FoFiX Team                                #
+# Copyright (C) 2009-2019 FoFiX Team                                #
 #                                                                   #
 # This program is free software; you can redistribute it and/or     #
 # modify it under the terms of the GNU General Public License       #
@@ -68,10 +68,7 @@ def find_command(cmd):
 
 def pc_exists(pkg):
     '''Check whether pkg-config thinks a library exists.'''
-    if os.spawnl(os.P_WAIT, pkg_config, 'pkg-config', '--print-errors', '--exists', pkg) == 0:
-        return True
-    else:
-        return False
+    return subprocess.call([pkg_config, '--print-errors', '--exists', pkg]) == 0
 
 
 def pc_info(pkg, altnames=[]):


### PR DESCRIPTION
This follows the [`subprocess` python doc](https://docs.python.org/2.7/library/subprocess.html#replacing-the-os-spawn-family) and the PEP 324.