### PR TITLE
deps: update requirements 2020.12

### DIFF
--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -5,6 +5,9 @@ Release notes
 ------------------
 
 - Deps: add a requirements.txt file
+- Deps: update Cython version
+- Deps: update NumPy version
+- Deps: do not pin requirements in `setup.py`
 - Windows: replace `dprintf` with `fdprintf` (MixStream)
 
 Details: https://github.com/fofix/fretwork/milestone/3?closed=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython>=0.27,<0.30
-numpy==1.13.3
-Pygame==1.9.3
-PyOpenGL==3.1.0
+Cython==0.29.21
+numpy==1.16.6
+Pygame==1.9.6
+PyOpenGL==3.1.5

--- a/setup.py
+++ b/setup.py
@@ -228,10 +228,10 @@ setup(
     keywords='music engine fofix frets game',
     setup_requires=['pytest-runner', 'cython'],
     install_requires=[
-        'Cython >= 0.27',
-        'Pygame == 1.9.3',
-        'PyOpenGL == 3.1.0',
-        'numpy == 1.13.3'
+        'Cython >= 0.29.2, < 3.0',
+        'Pygame < 2.0',
+        'PyOpenGL',
+        'numpy < 1.17'
     ],
     ext_modules=cythonize(mixstreamExt),
     test_suite="tests",


### PR DESCRIPTION
Update `cython`, `numpy`, `pygame` and `pyopengl`, and keep python 2 compat.
Do not pin requirements in `setup.py`.