### PR TITLE
ci(travis): clean up python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: python
 python:
     - 2.7
-    - 3.4
-    - 3.5
     - 3.6
-    - "3.7-dev"
+    - 3.7
+    - 3.8
+    - 3.9
+    - "3.10-dev"
 
 matrix:
     allow_failures:
-        - python: "3.7-dev"
+        - python: 3.7
+        - python: 3.8
+        - python: 3.9
+        - python: "3.10-dev"
 
 before_install:
     - sudo apt-get -qq update


### PR DESCRIPTION
Those python versions are added (failures allowed): 3.7, 3.8, 3.9, 3.10-dev.
Those python versions are removed: 3.4, 3.5, 3.7-dev.