### PR TITLE
build(setup): specify numpy versions & add some classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,10 +226,12 @@ setup(
     keywords='music engine fofix frets game',
     setup_requires=['pytest-runner', 'cython'],
     install_requires=[
-        'Cython >= 0.29.2, < 3.0',
-        'Pygame < 2.0',
-        'PyOpenGL',
-        'numpy < 1.17'
+        "Cython>=0.29.2,<3.0",
+        "Pygame<2.0",
+        "PyOpenGL",
+        "numpy<1.17;python_version<'3.4'",
+        "numpy<1.20;python_version=='3.6'",
+        "numpy;python_version>'3.6'",
     ],
     ext_modules=cythonize(mixstreamExt),
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Multimedia',
         'Topic :: Multimedia :: Sound/Audio',
         'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
Numpy versions are specified according to those of Python.
Fretwork is compatible with Python 3.7 and 3.8.