### PR TITLE
ci(gha): make py38 tests mandatory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8']
         experimental: [false]
 
         include:
-          - python-version: '3.8'
-            experimental: true
           - python-version: '3.9'
             experimental: true
           - python-version: '3.10'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/fofix/fretwork/badge.svg?branch=master)](https://coveralls.io/github/fofix/fretwork?branch=master)
 [![Tests Status](https://github.com/fofix/fretwork/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/fofix/fretwork/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/fretwork/badge/?version=latest)](http://fretwork.readthedocs.io/en/latest/?badge=latest)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/fretwork.svg)](https://pypi.python.org/pypi/fretwork)
 [![PyPI](https://img.shields.io/pypi/v/fretwork.svg)](https://pypi.org/project/fretwork/)
 
 


### PR DESCRIPTION
Supported python versions are displayed in the README too.