### PR TITLE
ci(github): clean up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: tests on ${{ matrix.python-version }}
+    name: "tests on ${{ matrix.python-version }} (optional: ${{ matrix.experimental }})"
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -38,12 +38,14 @@ jobs:
             libsoundtouch-dev \
             libvorbis-dev
 
-      - name: Install python dependencies
+      - name: "Install python dependencies (optional: ${{ matrix.experimental }})"
+        continue-on-error: ${{ matrix.experimental }}
         run: |
           pip install coverage pytest pytest-cov
           pip install -r requirements.txt
 
-      - name: Run tests
+      - name: "Run tests (optional: ${{ matrix.experimental }})"
+        continue-on-error: ${{ matrix.experimental }}
         run: |
           python setup.py check
           pytest --cov=fretwork

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,18 +30,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install os dependencies
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get install -yq \
-            libportmidi-dev \
-            libsdl-image1.2-dev \
-            libsdl-mixer1.2-dev \
-            libsdl-ttf2.0-dev \
-            libsdl1.2-dev \
-            libsoundtouch-dev \
-            libvorbis-dev
-
       - name: "Install python dependencies (optional: ${{ matrix.experimental }})"
         continue-on-error: ${{ matrix.experimental }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         experimental: [false]
 
+        include:
+          - python-version: '3.11'
+            experimental: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -12,20 +12,6 @@ Shared code for FoFiX and FoF:R.
 
 ## Setup
 
-### Dependencies
-
-You'll need those packages to run tests:
-* `glib`
-* `sdl 1.2`
-* `sdl_mixer 1.2`
-* `libogg`
-* `libvorbisfile`
-* `libtheora`
-* `soundtouch`
-
-For Windows, you should use the [win32 dependency pack](https://www.dropbox.com/s/p8xv4pktq670q9i/fofix-win32-deppack-20130304-updated.zip?dl=0) (to unzip into the win32 directory).
-
-
 ## Related links
 
 * Read the doc: https://fretwork.readthedocs.io


### PR DESCRIPTION
Some tests are now optional (py3.11).
OS dependencies installation step is not required for testing as all dependencies are coming with mixstream.